### PR TITLE
Provide a secure way to set parameters

### DIFF
--- a/environments/default/main.jsonnet
+++ b/environments/default/main.jsonnet
@@ -1,8 +1,9 @@
 local k = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet';
 
 {
-  _config:: {
+  _config+:: {
     hello: {
+      secrets: import 'secrets.jsonnet',
       port: 5000,
       name: 'hello-flask',
       init: {
@@ -18,6 +19,10 @@ local k = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet'
             --comment: create database
             CREATE DATABASE "exampledb";
             --rollback DROP DATABASE "exampledb";
+
+            --changeset jeremyspykerman:2
+            CREATE USER "${db.username}" WITH LOGIN ENCRYPTED PASSWORD '${db.password}';
+            --rollback DROP USER "exampleuser";
           |||,
           'bootstrap.properties': |||
             url: jdbc:postgresql://192.168.1.101:5432/postgres
@@ -35,6 +40,10 @@ local k = import 'github.com/grafana/jsonnet-libs/ksonnet-util/kausal.libsonnet'
         'update',
         '--password',
         'notasecret',
+        '-D',
+        'db.username=%s' % $._config.hello.secrets.db.username,
+        '-D',
+        'db.password=%s' % $._config.hello.secrets.db.password,
       ],
     },
   },

--- a/environments/default/secrets.jsonnet
+++ b/environments/default/secrets.jsonnet
@@ -1,0 +1,10 @@
+// this is not a real way to manage secrets
+// this would be OK if the contents of this file
+// were encrypted with git-crypt or provided by
+// hashicorp vault
+{
+  db: {
+    username: 'exampleuser',
+    password: 'alsonotasecret',
+  },
+}


### PR DESCRIPTION
This is only in the direction of securely setting parameters.

Given the parameters are set on the command line directly, the security
sensitive values should probably be moved to an actually k8s secret so
they can be passed as secret environment values.

That said, this does demonstrate how not to hard-code the username and
password for our database user.